### PR TITLE
Use provider and viewModel for live page

### DIFF
--- a/lib/common/component/custom_constraints.dart
+++ b/lib/common/component/custom_constraints.dart
@@ -1,6 +1,0 @@
-import 'package:flutter/material.dart';
-
-class CustomConstraints {
-  static const pageBoxConstraints =
-      BoxConstraints(minWidth: 350, maxWidth: 600);
-}

--- a/lib/common/component/retryable_error_view.dart
+++ b/lib/common/component/retryable_error_view.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:thaivtuberranking/common/component/thai_text.dart';
+
+class RetryableErrorView extends StatelessWidget {
+  final String title;
+  final String message;
+  final Function() retryAction;
+
+  const RetryableErrorView(
+      {Key? key,
+      this.title = "Error",
+      required this.message,
+      required this.retryAction})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        child: Align(
+            alignment: Alignment.center,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Padding(
+                    padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
+                    child: ThaiText(
+                        text: title,
+                        color: Colors.red,
+                        fontWeight: FontWeight.bold)),
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: ThaiText(text: message, color: Colors.black54),
+                ),
+                ElevatedButton(
+                  onPressed: retryAction,
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ThaiText(
+                      text: "Reload",
+                      color: Colors.white,
+                    ),
+                  ),
+                )
+              ],
+            )));
+  }
+}

--- a/lib/pages/channel/channel_page.dart
+++ b/lib/pages/channel/channel_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:thaivtuberranking/common/component/center_circular_progress_indicator.dart';
-import 'package:thaivtuberranking/common/component/custom_constraints.dart';
 import 'package:thaivtuberranking/common/component/error_dialog.dart';
 import 'package:thaivtuberranking/common/component/thai_text.dart';
 import 'package:thaivtuberranking/pages/channel/channel_repository.dart';
@@ -97,8 +96,7 @@ class _ChannelPageState extends State<ChannelPage> {
                       _buildChartDataView(),
                       _buildRawDataLink()
                     ],
-                  ),
-                  constraints: CustomConstraints.pageBoxConstraints)));
+                  ))));
     } else {
       body = CenterCircularProgressIndicator();
     }

--- a/lib/pages/channel_ranking/channel_ranking_page.dart
+++ b/lib/pages/channel_ranking/channel_ranking_page.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:thaivtuberranking/common/component/custom_constraints.dart';
 import 'package:thaivtuberranking/common/component/empty_error_notification.dart';
 import 'package:thaivtuberranking/pages/channel/channel_page.dart';
 import 'package:thaivtuberranking/pages/channel_ranking/channel_ranking_repository.dart';
@@ -231,7 +230,6 @@ class _ChannelRankingPageState extends State<ChannelRankingPage>
           ),
         ],
       ),
-      constraints: CustomConstraints.pageBoxConstraints,
     ));
   }
 

--- a/lib/pages/live/live_page.dart
+++ b/lib/pages/live/live_page.dart
@@ -70,7 +70,7 @@ class _LivePageState extends State<LivePage> {
             // }
             if (liveViewModel.isLoading) {
               return CenterCircularProgressIndicator();
-            } else if (liveViewModel.getFilteredLiveVideos().isEmpty) {
+            } else if (liveViewModel.filteredLiveVideos.isEmpty) {
               return _emptyVideoWidget;
             } else {
               return _liveVideosWidget;
@@ -91,16 +91,16 @@ class _LivePageState extends State<LivePage> {
   }
 
   Widget get _liveVideosWidget {
-    final filteredLiveVideos = liveViewModel.getFilteredLiveVideos();
-    int itemCount = filteredLiveVideos.length;
+    int itemCount = liveViewModel.filteredLiveVideos.length;
     var listView = ListView.builder(
       controller: _scrollController,
       itemBuilder: (context, index) {
         return Container(
             child: Ink(
-                color: _buildRowColor(index, filteredLiveVideos[index]),
+                color: _buildRowColor(
+                    index, liveViewModel.filteredLiveVideos[index]),
                 child: LiveVideoListTile(
-                  item: filteredLiveVideos[index],
+                  item: liveViewModel.filteredLiveVideos[index],
                   onTap: (liveVideo) {
                     UrlLauncher.launchURL(liveVideo.getVideoUrl());
                     MyApp.analytics.sendAnalyticsEvent(

--- a/lib/pages/live/live_page.dart
+++ b/lib/pages/live/live_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:thaivtuberranking/common/component/center_circular_progress_indicator.dart';
+import 'package:thaivtuberranking/common/component/retryable_error_view.dart';
 import 'package:thaivtuberranking/main.dart';
 import 'package:thaivtuberranking/common/component/thai_text.dart';
 import 'package:thaivtuberranking/pages/channel/channel_page.dart';
@@ -9,6 +10,7 @@ import 'package:thaivtuberranking/pages/live/component/live_video_listtile.dart'
 import 'package:thaivtuberranking/pages/live/entity/live_video.dart';
 import 'package:thaivtuberranking/pages/live/live_view_model.dart';
 import 'package:thaivtuberranking/services/analytics.dart';
+import 'package:thaivtuberranking/services/result.dart';
 import 'package:thaivtuberranking/services/url_launcher.dart';
 import 'package:provider/provider.dart';
 
@@ -61,15 +63,16 @@ class _LivePageState extends State<LivePage> {
         create: (context) => _liveViewModel,
         child: Consumer<LiveViewModel>(
           builder: (context, liveViewModel, _) {
-            // if (liveViewModel.errorMessage != null) {
-            //   ErrorDialog.showErrorDialog(
-            //       'ไม่สามารถโหลดข้อมูลไลฟ์ได้\nโปรดลองใหม่ในภายหลัง',
-            //       liveViewModel.errorMessage,
-            //       context);
-            //   liveViewModel.clearErrorMessage();
-            // }
-            if (liveViewModel.isLoading) {
+            if (liveViewModel.viewState is LoadingState) {
               return CenterCircularProgressIndicator();
+            } else if (liveViewModel.viewState is ErrorState) {
+              final errorMessage = (liveViewModel.viewState as ErrorState).msg;
+              return RetryableErrorView(
+                message: errorMessage,
+                retryAction: () {
+                  _liveViewModel.getLiveVideos();
+                },
+              );
             } else if (liveViewModel.filteredLiveVideos.isEmpty) {
               return _emptyVideoWidget;
             } else {

--- a/lib/pages/live/live_page.dart
+++ b/lib/pages/live/live_page.dart
@@ -71,15 +71,15 @@ class _LivePageState extends State<LivePage> {
             if (liveViewModel.isLoading) {
               return CenterCircularProgressIndicator();
             } else if (liveViewModel.getFilteredLiveVideos().isEmpty) {
-              return _buildEmptyWidget();
+              return _emptyVideoWidget;
             } else {
-              return _buildLiveVideosWidget();
+              return _liveVideosWidget;
             }
           },
         ));
   }
 
-  Widget _buildEmptyWidget() {
+  Widget get _emptyVideoWidget {
     return Container(
       child: Align(
           alignment: Alignment.center,
@@ -90,7 +90,7 @@ class _LivePageState extends State<LivePage> {
     );
   }
 
-  Widget _buildLiveVideosWidget() {
+  Widget get _liveVideosWidget {
     final filteredLiveVideos = liveViewModel.getFilteredLiveVideos();
     int itemCount = filteredLiveVideos.length;
     var listView = ListView.builder(

--- a/lib/pages/live/live_page.dart
+++ b/lib/pages/live/live_page.dart
@@ -29,7 +29,7 @@ class LivePage extends StatefulWidget {
 }
 
 class _LivePageState extends State<LivePage> {
-  late LiveViewModel liveViewModel = LiveViewModel(widget.originType);
+  late LiveViewModel _liveViewModel = LiveViewModel(widget.originType);
   ScrollController _scrollController = ScrollController();
 
   @override
@@ -46,7 +46,7 @@ class _LivePageState extends State<LivePage> {
         widget.didScrollUp();
       }
     });
-    liveViewModel.getLiveVideos();
+    _liveViewModel.getLiveVideos();
   }
 
   @override
@@ -58,9 +58,9 @@ class _LivePageState extends State<LivePage> {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-        create: (context) => liveViewModel,
+        create: (context) => _liveViewModel,
         child: Consumer<LiveViewModel>(
-          builder: (context, liveViewModel, child) {
+          builder: (context, liveViewModel, _) {
             // if (liveViewModel.errorMessage != null) {
             //   ErrorDialog.showErrorDialog(
             //       'ไม่สามารถโหลดข้อมูลไลฟ์ได้\nโปรดลองใหม่ในภายหลัง',
@@ -91,16 +91,16 @@ class _LivePageState extends State<LivePage> {
   }
 
   Widget get _liveVideosWidget {
-    int itemCount = liveViewModel.filteredLiveVideos.length;
+    int itemCount = _liveViewModel.filteredLiveVideos.length;
     var listView = ListView.builder(
       controller: _scrollController,
       itemBuilder: (context, index) {
         return Container(
             child: Ink(
                 color: _buildRowColor(
-                    index, liveViewModel.filteredLiveVideos[index]),
+                    index, _liveViewModel.filteredLiveVideos[index]),
                 child: LiveVideoListTile(
-                  item: liveViewModel.filteredLiveVideos[index],
+                  item: _liveViewModel.filteredLiveVideos[index],
                   onTap: (liveVideo) {
                     UrlLauncher.launchURL(liveVideo.getVideoUrl());
                     MyApp.analytics.sendAnalyticsEvent(

--- a/lib/pages/live/live_page.dart
+++ b/lib/pages/live/live_page.dart
@@ -1,18 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:thaivtuberranking/common/component/center_circular_progress_indicator.dart';
-import 'package:thaivtuberranking/common/component/custom_constraints.dart';
-import 'package:thaivtuberranking/common/component/error_dialog.dart';
 import 'package:thaivtuberranking/main.dart';
 import 'package:thaivtuberranking/common/component/thai_text.dart';
 import 'package:thaivtuberranking/pages/channel/channel_page.dart';
 import 'package:thaivtuberranking/pages/home/entity/origin_type.dart';
 import 'package:thaivtuberranking/pages/live/component/live_video_listtile.dart';
 import 'package:thaivtuberranking/pages/live/entity/live_video.dart';
-import 'package:thaivtuberranking/pages/live/live_repository.dart';
+import 'package:thaivtuberranking/pages/live/live_view_model.dart';
 import 'package:thaivtuberranking/services/analytics.dart';
-import 'package:thaivtuberranking/services/result.dart';
 import 'package:thaivtuberranking/services/url_launcher.dart';
+import 'package:provider/provider.dart';
 
 class LivePage extends StatefulWidget {
   final OriginType originType;
@@ -31,9 +29,7 @@ class LivePage extends StatefulWidget {
 }
 
 class _LivePageState extends State<LivePage> {
-  final LiveRepository _repository = LiveRepository();
-  List<LiveVideo> _liveVideos = [];
-  bool _isLoading = true;
+  late LiveViewModel liveViewModel = LiveViewModel(widget.originType);
   ScrollController _scrollController = ScrollController();
 
   @override
@@ -50,7 +46,7 @@ class _LivePageState extends State<LivePage> {
         widget.didScrollUp();
       }
     });
-    loadData();
+    liveViewModel.getLiveVideos();
   }
 
   @override
@@ -59,58 +55,28 @@ class _LivePageState extends State<LivePage> {
     _scrollController.dispose();
   }
 
-  void loadData() async {
-    final result = await _repository.getLiveVideos();
-    if (result is SuccessState) {
-      setState(() {
-        _liveVideos = result.value;
-        _isLoading = false;
-      });
-    } else if (result is ErrorState) {
-      ErrorDialog.showErrorDialog(
-          'ไม่สามารถโหลดข้อมูลไลฟ์ได้\nโปรดลองใหม่ในภายหลัง',
-          result.msg,
-          context);
-      setState(() {
-        _isLoading = false;
-      });
-    } else {
-      setState(() {
-        _isLoading = true;
-      });
-    }
-  }
-
-  List<LiveVideo> _getFilteredLiveVideos() {
-    switch (widget.originType) {
-      case OriginType.OriginalOnly:
-        return _liveVideos
-            .where((element) => (!element.channelIsRebranded))
-            .toList();
-      case OriginType.All:
-        return _liveVideos;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    Widget body;
-    if (_isLoading) {
-      body = CenterCircularProgressIndicator();
-    } else {
-      List<LiveVideo> liveVideos = _getFilteredLiveVideos();
-      if (liveVideos.isEmpty) {
-        body = _buildEmptyWidget();
-      } else {
-        body = _buildLiveVideosWidget();
-      }
-    }
-    return Center(
-      child: Container(
-        child: body,
-        constraints: CustomConstraints.pageBoxConstraints,
-      ),
-    );
+    return ChangeNotifierProvider(
+        create: (context) => liveViewModel,
+        child: Consumer<LiveViewModel>(
+          builder: (context, liveViewModel, child) {
+            // if (liveViewModel.errorMessage != null) {
+            //   ErrorDialog.showErrorDialog(
+            //       'ไม่สามารถโหลดข้อมูลไลฟ์ได้\nโปรดลองใหม่ในภายหลัง',
+            //       liveViewModel.errorMessage,
+            //       context);
+            //   liveViewModel.clearErrorMessage();
+            // }
+            if (liveViewModel.isLoading) {
+              return CenterCircularProgressIndicator();
+            } else if (liveViewModel.getFilteredLiveVideos().isEmpty) {
+              return _buildEmptyWidget();
+            } else {
+              return _buildLiveVideosWidget();
+            }
+          },
+        ));
   }
 
   Widget _buildEmptyWidget() {
@@ -125,42 +91,39 @@ class _LivePageState extends State<LivePage> {
   }
 
   Widget _buildLiveVideosWidget() {
-    if (_liveVideos.isEmpty) {
-      return _buildEmptyWidget();
-    } else {
-      int itemCount = _liveVideos.length;
-      var listView = ListView.builder(
-        controller: _scrollController,
-        itemBuilder: (context, index) {
-          return Container(
-              child: Ink(
-                  color: _buildRowColor(index, _liveVideos[index]),
-                  child: LiveVideoListTile(
-                    item: _liveVideos[index],
-                    onTap: (liveVideo) {
-                      UrlLauncher.launchURL(liveVideo.getVideoUrl());
-                      MyApp.analytics.sendAnalyticsEvent(
-                          AnalyticsEvent.open_video_url,
-                          {'url': liveVideo.getVideoUrl()});
-                    },
-                    onTapChannelName: (liveVideo) {
-                      Navigator.pushNamed(context, ChannelPage.route,
-                          arguments: liveVideo.channelId);
-                      MyApp.analytics.sendAnalyticsEvent(
-                          AnalyticsEvent.view_detail, {
-                        'channel_id': liveVideo.channelId,
-                        'channel_name': liveVideo.channelTitle
-                      });
-                    },
-                  )));
-        },
-        itemCount: itemCount,
-      );
+    final filteredLiveVideos = liveViewModel.getFilteredLiveVideos();
+    int itemCount = filteredLiveVideos.length;
+    var listView = ListView.builder(
+      controller: _scrollController,
+      itemBuilder: (context, index) {
+        return Container(
+            child: Ink(
+                color: _buildRowColor(index, filteredLiveVideos[index]),
+                child: LiveVideoListTile(
+                  item: filteredLiveVideos[index],
+                  onTap: (liveVideo) {
+                    UrlLauncher.launchURL(liveVideo.getVideoUrl());
+                    MyApp.analytics.sendAnalyticsEvent(
+                        AnalyticsEvent.open_video_url,
+                        {'url': liveVideo.getVideoUrl()});
+                  },
+                  onTapChannelName: (liveVideo) {
+                    Navigator.pushNamed(context, ChannelPage.route,
+                        arguments: liveVideo.channelId);
+                    MyApp.analytics.sendAnalyticsEvent(
+                        AnalyticsEvent.view_detail, {
+                      'channel_id': liveVideo.channelId,
+                      'channel_name': liveVideo.channelTitle
+                    });
+                  },
+                )));
+      },
+      itemCount: itemCount,
+    );
 
-      return Container(
-        child: listView,
-      );
-    }
+    return Container(
+      child: listView,
+    );
   }
 
   Color? _buildRowColor(int index, LiveVideo liveVideo) {

--- a/lib/pages/live/live_view_model.dart
+++ b/lib/pages/live/live_view_model.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:thaivtuberranking/pages/home/entity/origin_type.dart';
+import 'package:thaivtuberranking/pages/live/entity/live_video.dart';
+import 'package:thaivtuberranking/pages/live/live_repository.dart';
+import 'package:thaivtuberranking/services/result.dart';
+
+class LiveViewModel extends ChangeNotifier {
+  final OriginType originType;
+  final LiveRepository _repository = LiveRepository();
+
+  bool isLoading = false;
+  String? errorMessage;
+
+  List<LiveVideo> _liveVideos = [];
+
+  LiveViewModel(this.originType);
+
+  void getLiveVideos() async {
+    isLoading = true;
+    final result = await _repository.getLiveVideos();
+    isLoading = false;
+    if (result is SuccessState) {
+      _liveVideos = result.value;
+    } else if (result is ErrorState) {
+      errorMessage = result.msg;
+    }
+    notifyListeners();
+  }
+
+  List<LiveVideo> getFilteredLiveVideos() {
+    switch (originType) {
+      case OriginType.OriginalOnly:
+        return _liveVideos
+            .where((element) => (!element.channelIsRebranded))
+            .toList();
+      case OriginType.All:
+        return _liveVideos;
+    }
+  }
+
+  void clearErrorMessage() {
+    errorMessage = null;
+  }
+}

--- a/lib/pages/live/live_view_model.dart
+++ b/lib/pages/live/live_view_model.dart
@@ -27,7 +27,7 @@ class LiveViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  List<LiveVideo> getFilteredLiveVideos() {
+  List<LiveVideo> get filteredLiveVideos {
     switch (originType) {
       case OriginType.OriginalOnly:
         return _liveVideos

--- a/lib/pages/live/live_view_model.dart
+++ b/lib/pages/live/live_view_model.dart
@@ -8,37 +8,29 @@ class LiveViewModel extends ChangeNotifier {
   final OriginType originType;
   final LiveRepository _repository = LiveRepository();
 
-  bool isLoading = false;
-  String? errorMessage;
-
-  List<LiveVideo> _liveVideos = [];
+  Result viewState = Result.loading();
 
   LiveViewModel(this.originType);
 
   void getLiveVideos() async {
-    isLoading = true;
+    viewState = Result.loading();
     final result = await _repository.getLiveVideos();
-    isLoading = false;
-    if (result is SuccessState) {
-      _liveVideos = result.value;
-    } else if (result is ErrorState) {
-      errorMessage = result.msg;
-    }
+    viewState = result;
     notifyListeners();
   }
 
   List<LiveVideo> get filteredLiveVideos {
-    switch (originType) {
-      case OriginType.OriginalOnly:
-        return _liveVideos
-            .where((element) => (!element.channelIsRebranded))
-            .toList();
-      case OriginType.All:
-        return _liveVideos;
+    if (viewState is SuccessState<List<LiveVideo>>) {
+      final liveVideos = (viewState as SuccessState<List<LiveVideo>>).value;
+      switch (originType) {
+        case OriginType.OriginalOnly:
+          return liveVideos
+              .where((element) => (!element.channelIsRebranded))
+              .toList();
+        case OriginType.All:
+          return liveVideos;
+      }
     }
-  }
-
-  void clearErrorMessage() {
-    errorMessage = null;
+    return [];
   }
 }

--- a/lib/pages/video_ranking/video_ranking_page.dart
+++ b/lib/pages/video_ranking/video_ranking_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:thaivtuberranking/common/component/center_circular_progress_indicator.dart';
-import 'package:thaivtuberranking/common/component/custom_constraints.dart';
 import 'package:thaivtuberranking/common/component/empty_error_notification.dart';
 import 'package:thaivtuberranking/common/component/error_dialog.dart';
 import 'package:thaivtuberranking/main.dart';
@@ -122,7 +121,6 @@ class _VideoRankingPageState extends State<VideoRankingPage> {
     return Align(
       child: Container(
         child: body,
-        constraints: CustomConstraints.pageBoxConstraints,
       ),
       alignment: Alignment.topCenter,
     );

--- a/lib/services/result.dart
+++ b/lib/services/result.dart
@@ -1,7 +1,7 @@
 class Result<T> {
   Result._();
 
-  factory Result.loading(T msg) = LoadingState<T>;
+  factory Result.loading() = LoadingState<T>;
 
   factory Result.success(T value) = SuccessState<T>;
 
@@ -9,8 +9,7 @@ class Result<T> {
 }
 
 class LoadingState<T> extends Result<T> {
-  LoadingState(this.msg) : super._();
-  final T msg;
+  LoadingState() : super._();
 }
 
 class ErrorState<T> extends Result<T> {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   oktoast:
     dependency: "direct main"
     description:
@@ -268,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.3"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
   search_page:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   fl_chart: ^0.40.0
   search_page: ^2.0.0+1
   syncfusion_flutter_charts: ^19.1.63
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
https://github.com/chuymaster/thaivtuberranking-frontend/issues/39
- Use provider pattern for Live Page only
- Fix to show error view instead of dialog due to `Consumer` building method cannot show error dialog
- Remove `pageBoxConstraints` since it's not working in provider pattern. Will redesign it with responsive design later.

References
- https://levelup.gitconnected.com/state-management-in-flutter-using-provider-1dc2a8e9f2b1
- https://note.com/yasukotelin/n/n3cdd311fb336
- https://medium.com/@aruny3/how-to-use-changenotifier-in-flutter-440371617b8c