### PR TITLE
Fix FirebaseAnalytics got overwritten 😰

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,6 @@ class MyApp extends StatelessWidget {
     } else {
       analytics = Analytics(analytics: null, observer: null);
     }
-    analytics = Analytics();
   }
 
   // This widget is the root of your application.


### PR DESCRIPTION
`Analytics` class got overwritten so events were not sent for a long time...

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/8290104/154673746-f2276b5d-5530-461f-a0ee-bb2065398e8b.png">
