### PR TITLE
Update channel request limit

### DIFF
--- a/lib/admin/channel_request/channel_request_repository.dart
+++ b/lib/admin/channel_request/channel_request_repository.dart
@@ -9,7 +9,7 @@ import '../endpoint.dart';
 import 'entity/channel_request.dart';
 
 class ChannelRequestRepository {
-  final int _limit = 50;
+  final int _limit = 100;
 
   Future<Result> getChannelRequests() async {
     Uri uri = Uri.parse(Endpoint.getChannelRequestList);


### PR DESCRIPTION
## Summary
- bump the `_limit` constant in `ChannelRequestRepository` to fetch up to 100 items

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821a62a9748331ba3352927334d9e3