### PR TITLE
Bump channel request limit to 200

### DIFF
--- a/lib/admin/channel_request/channel_request_repository.dart
+++ b/lib/admin/channel_request/channel_request_repository.dart
@@ -9,7 +9,8 @@ import '../endpoint.dart';
 import 'entity/channel_request.dart';
 
 class ChannelRequestRepository {
-  final int _limit = 50;
+  // Increased default fetch size so the admin UI can load more requests
+  final int _limit = 200;
 
   Future<Result> getChannelRequests() async {
     Uri uri = Uri.parse(Endpoint.getChannelRequestList);


### PR DESCRIPTION
## Summary
- increase `_limit` in `ChannelRequestRepository` so up to 200 channel requests are returned

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821a62a9748331ba3352927334d9e3